### PR TITLE
Open treatment form when appointment marked complete

### DIFF
--- a/lib/screens/treatment_add.dart
+++ b/lib/screens/treatment_add.dart
@@ -11,6 +11,9 @@ import '../models/treatment.dart';
 void showTreatmentDialog(
   BuildContext context, {
   required String patientId,
+  String? patientName,
+  String? initialProcedure,
+  DateTime? initialDate,
   Treatment? treatment,
 }) {
   showDialog(
@@ -29,6 +32,9 @@ void showTreatmentDialog(
             padding: const EdgeInsets.all(16.0),
             child: TreatmentForm(
               patientId: patientId,
+              patientName: patientName,
+              initialProcedure: initialProcedure,
+              initialDate: initialDate,
               treatment: treatment,
             ),
           ),

--- a/lib/widgets/appointment_detail_dialog.dart
+++ b/lib/widgets/appointment_detail_dialog.dart
@@ -8,6 +8,7 @@ import '../services/appointment_service.dart';
 import '../services/patient_service.dart';
 import '../services/rating_service.dart';
 import '../screens/appointment_add.dart';
+import '../screens/treatment_add.dart';
 import '../models/appointment_model.dart';
 import '../styles/app_theme.dart';
 
@@ -170,6 +171,15 @@ class _AppointmentDetailDialogState extends State<AppointmentDetailDialog> {
 
       if (mounted) {
         Navigator.pop(context);
+        if (_currentStatus == 'เสร็จสิ้น') {
+          showTreatmentDialog(
+            context,
+            patientId: widget.patient.patientId,
+            patientName: widget.patient.name,
+            initialProcedure: widget.appointment.treatment,
+            initialDate: widget.appointment.startTime,
+          );
+        }
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
             content: Text('บันทึกการเปลี่ยนแปลงเรียบร้อยแล้ว'),

--- a/lib/widgets/treatment_form.dart
+++ b/lib/widgets/treatment_form.dart
@@ -13,8 +13,18 @@ import '../styles/app_theme.dart';
 class TreatmentForm extends StatefulWidget {
   final String patientId;
   final Treatment? treatment;
+  final String? patientName;
+  final String? initialProcedure;
+  final DateTime? initialDate;
 
-  const TreatmentForm({super.key, required this.patientId, this.treatment});
+  const TreatmentForm({
+    super.key,
+    required this.patientId,
+    this.treatment,
+    this.patientName,
+    this.initialProcedure,
+    this.initialDate,
+  });
 
   @override
   State<TreatmentForm> createState() => _TreatmentFormState();
@@ -45,6 +55,9 @@ class _TreatmentFormState extends State<TreatmentForm> {
       _selectedDate = t.date;
       _existingImageUrls = List.from(t.imageUrls);
       _notesController.text = t.notes ?? '';
+    } else {
+      _procedureController.text = widget.initialProcedure ?? '';
+      _selectedDate = widget.initialDate;
     }
   }
 
@@ -216,6 +229,21 @@ class _TreatmentFormState extends State<TreatmentForm> {
                 ),
               ],
             ),
+            if (widget.patientName != null && widget.patientName!.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 8.0),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    widget.patientName!,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w500,
+                      color: Colors.black87,
+                    ),
+                  ),
+                ),
+              ),
             Align(
               alignment: Alignment.centerRight,
               child: ElevatedButton.icon(


### PR DESCRIPTION
## Summary
- Launch treatment entry dialog automatically when an appointment's status is changed to complete, prefilled with patient, treatment and date details.
- Extend treatment dialog and form to accept initial patient information and display it for quick entry.
- Update appointment details dialog to trigger the treatment form upon completion.

## Testing
- `flutter analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68971c0bf104832b9e0ae418498583df