### PR TITLE
Open treatment form when appointment marked complete

### DIFF
--- a/lib/screens/treatment_add.dart
+++ b/lib/screens/treatment_add.dart
@@ -11,6 +11,11 @@ import '../models/treatment.dart';
 void showTreatmentDialog(
   BuildContext context, {
   required String patientId,
+  String? patientName,
+  String? initialProcedure,
+  String? initialToothNumber,
+  double? initialPrice,
+  DateTime? initialDate,
   Treatment? treatment,
 }) {
   showDialog(
@@ -29,6 +34,11 @@ void showTreatmentDialog(
             padding: const EdgeInsets.all(16.0),
             child: TreatmentForm(
               patientId: patientId,
+              patientName: patientName,
+              initialProcedure: initialProcedure,
+              initialToothNumber: initialToothNumber,
+              initialPrice: initialPrice,
+              initialDate: initialDate,
               treatment: treatment,
             ),
           ),

--- a/lib/widgets/appointment_detail_dialog.dart
+++ b/lib/widgets/appointment_detail_dialog.dart
@@ -8,8 +8,10 @@ import '../services/appointment_service.dart';
 import '../services/patient_service.dart';
 import '../services/rating_service.dart';
 import '../screens/appointment_add.dart';
+import '../screens/treatment_add.dart';
 import '../models/appointment_model.dart';
 import '../styles/app_theme.dart';
+import '../services/treatment_master_service.dart';
 
 class AppointmentDetailDialog extends StatefulWidget {
   final AppointmentModel appointment;
@@ -167,9 +169,32 @@ class _AppointmentDetailDialogState extends State<AppointmentDetailDialog> {
       if (newRating != currentRating) {
         await _patientService.updatePatientRating(widget.patient.patientId, newRating);
       }
+      double? initialPrice;
+      if (_currentStatus == 'เสร็จสิ้น') {
+        try {
+          final masters = await TreatmentMasterService.getAllTreatments().first;
+          for (final m in masters) {
+            if (m.name == widget.appointment.treatment) {
+              initialPrice = m.price;
+              break;
+            }
+          }
+        } catch (_) {}
+      }
 
       if (mounted) {
         Navigator.pop(context);
+        if (_currentStatus == 'เสร็จสิ้น') {
+          showTreatmentDialog(
+            context,
+            patientId: widget.patient.patientId,
+            patientName: widget.patient.name,
+            initialProcedure: widget.appointment.treatment,
+            initialToothNumber: widget.appointment.teeth?.join(', '),
+            initialPrice: initialPrice,
+            initialDate: widget.appointment.startTime,
+          );
+        }
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
             content: Text('บันทึกการเปลี่ยนแปลงเรียบร้อยแล้ว'),

--- a/lib/widgets/treatment_form.dart
+++ b/lib/widgets/treatment_form.dart
@@ -13,8 +13,22 @@ import '../styles/app_theme.dart';
 class TreatmentForm extends StatefulWidget {
   final String patientId;
   final Treatment? treatment;
+  final String? patientName;
+  final String? initialProcedure;
+  final DateTime? initialDate;
+  final String? initialToothNumber;
+  final double? initialPrice;
 
-  const TreatmentForm({super.key, required this.patientId, this.treatment});
+  const TreatmentForm({
+    super.key,
+    required this.patientId,
+    this.treatment,
+    this.patientName,
+    this.initialProcedure,
+    this.initialDate,
+    this.initialToothNumber,
+    this.initialPrice,
+  });
 
   @override
   State<TreatmentForm> createState() => _TreatmentFormState();
@@ -45,6 +59,13 @@ class _TreatmentFormState extends State<TreatmentForm> {
       _selectedDate = t.date;
       _existingImageUrls = List.from(t.imageUrls);
       _notesController.text = t.notes ?? '';
+    } else {
+      _procedureController.text = widget.initialProcedure ?? '';
+      _toothNumberController.text = widget.initialToothNumber ?? '';
+      if (widget.initialPrice != null) {
+        _priceController.text = widget.initialPrice!.toStringAsFixed(0);
+      }
+      _selectedDate = widget.initialDate;
     }
   }
 
@@ -216,6 +237,21 @@ class _TreatmentFormState extends State<TreatmentForm> {
                 ),
               ],
             ),
+            if (widget.patientName != null && widget.patientName!.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 8.0),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    widget.patientName!,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w500,
+                      color: Colors.black87,
+                    ),
+                  ),
+                ),
+              ),
             Align(
               alignment: Alignment.centerRight,
               child: ElevatedButton.icon(


### PR DESCRIPTION
## Summary
- Extend treatment dialog and form to accept tooth numbers and initial price
- When saving a completed appointment, lookup treatment price and open form pre-filled with patient, treatment, tooth and price

## Testing
- `dart format lib/screens/treatment_add.dart lib/widgets/treatment_form.dart lib/widgets/appointment_detail_dialog.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68971c0bf104832b9e0ae418498583df