### PR TITLE
Prefill tooth and price when converting appointment to treatment

### DIFF
--- a/lib/screens/treatment_add.dart
+++ b/lib/screens/treatment_add.dart
@@ -14,6 +14,8 @@ void showTreatmentDialog(
   String? patientName,
   String? initialProcedure,
   DateTime? initialDate,
+  String? initialToothNumber,
+  double? initialPrice,
   Treatment? treatment,
 }) {
   showDialog(
@@ -35,6 +37,8 @@ void showTreatmentDialog(
               patientName: patientName,
               initialProcedure: initialProcedure,
               initialDate: initialDate,
+              initialToothNumber: initialToothNumber,
+              initialPrice: initialPrice,
               treatment: treatment,
             ),
           ),

--- a/lib/services/treatment_master_service.dart
+++ b/lib/services/treatment_master_service.dart
@@ -34,6 +34,15 @@ class TreatmentMasterService {
     await _collection.doc(treatmentId).delete();
   }
 
+  // 📌 ดึงข้อมูลหัตถการตามชื่อ เพื่อใช้เติมราคาอัตโนมัติ
+  static Future<TreatmentMaster?> getTreatmentByName(String name) async {
+    final snapshot =
+        await _collection.where('name', isEqualTo: name).limit(1).get();
+    if (snapshot.docs.isEmpty) return null;
+    final doc = snapshot.docs.first;
+    return TreatmentMaster.fromMap(doc.data(), doc.id);
+  }
+
   // 🧵✨ [CHANGED v1.1] ปรับปรุงเมธอดนี้ให้คืนค่า ID ของ Master กลับมาด้วย
   // ไม่ว่าจะเป็น ID ของรายการที่มีอยู่แล้ว หรือ ID ของรายการที่เพิ่งสร้างใหม่
   static Future<String> addIfNotExist(String name, double price) async {

--- a/lib/widgets/appointment_detail_dialog.dart
+++ b/lib/widgets/appointment_detail_dialog.dart
@@ -7,6 +7,7 @@ import '../models/patient.dart';
 import '../services/appointment_service.dart';
 import '../services/patient_service.dart';
 import '../services/rating_service.dart';
+import '../services/treatment_master_service.dart';
 import '../screens/appointment_add.dart';
 import '../screens/treatment_add.dart';
 import '../models/appointment_model.dart';
@@ -168,6 +169,12 @@ class _AppointmentDetailDialogState extends State<AppointmentDetailDialog> {
       if (newRating != currentRating) {
         await _patientService.updatePatientRating(widget.patient.patientId, newRating);
       }
+      double? initialPrice;
+      if (_currentStatus == 'เสร็จสิ้น') {
+        final master =
+            await TreatmentMasterService.getTreatmentByName(widget.appointment.treatment);
+        initialPrice = master?.price;
+      }
 
       if (mounted) {
         Navigator.pop(context);
@@ -178,6 +185,9 @@ class _AppointmentDetailDialogState extends State<AppointmentDetailDialog> {
             patientName: widget.patient.name,
             initialProcedure: widget.appointment.treatment,
             initialDate: widget.appointment.startTime,
+            initialToothNumber:
+                widget.appointment.teeth?.join(', '),
+            initialPrice: initialPrice,
           );
         }
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/widgets/treatment_form.dart
+++ b/lib/widgets/treatment_form.dart
@@ -16,6 +16,8 @@ class TreatmentForm extends StatefulWidget {
   final String? patientName;
   final String? initialProcedure;
   final DateTime? initialDate;
+  final String? initialToothNumber;
+  final double? initialPrice;
 
   const TreatmentForm({
     super.key,
@@ -24,6 +26,8 @@ class TreatmentForm extends StatefulWidget {
     this.patientName,
     this.initialProcedure,
     this.initialDate,
+    this.initialToothNumber,
+    this.initialPrice,
   });
 
   @override
@@ -58,6 +62,10 @@ class _TreatmentFormState extends State<TreatmentForm> {
     } else {
       _procedureController.text = widget.initialProcedure ?? '';
       _selectedDate = widget.initialDate;
+      _toothNumberController.text = widget.initialToothNumber ?? '';
+      _priceController.text = widget.initialPrice != null
+          ? widget.initialPrice!.toStringAsFixed(0)
+          : '';
     }
   }
 


### PR DESCRIPTION
## Summary
- pass tooth numbers and price into treatment add dialog when completing appointments
- allow TreatmentForm to accept initial tooth and price values
- fetch treatment price from master data by name

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897338efd74832bae65925e1f67d9fc