### PR TITLE
Add Bluetooth thermal printing capability

### DIFF
--- a/lib/features/printing/render/appointment_slip_preview_page.dart
+++ b/lib/features/printing/render/appointment_slip_preview_page.dart
@@ -10,6 +10,7 @@ import 'package:flutter/rendering.dart' show RenderRepaintBoundary; // สำห
 import 'package:flutter/services.dart' show rootBundle, ByteData;
 import '../utils/th_format.dart';
 import '../domain/appointment_slip_model.dart';
+import '../services/thermal_printer_service.dart';
 
 class AppointmentSlipPreviewPage extends StatefulWidget {
   final AppointmentSlipModel slip;
@@ -99,9 +100,17 @@ class _AppointmentSlipPreviewPageState extends State<AppointmentSlipPreviewPage>
   }
 
   Future<void> _sendToPrinter() async {
-    if (kDebugMode) {
+    if (_png == null) return;
+    try {
+      await ThermalPrinterService.instance.printImage(_png!);
+      if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('สาธิต: ส่งภาพใบนัด (${_png?.lengthInBytes ?? 0} bytes) ไปเครื่องพิมพ์')),
+        const SnackBar(content: Text('ส่งไปยังเครื่องพิมพ์เรียบร้อย')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('พิมพ์ล้มเหลว: $e')),
       );
     }
   }

--- a/lib/features/printing/render/receipt_renderer_mydent.dart
+++ b/lib/features/printing/render/receipt_renderer_mydent.dart
@@ -9,6 +9,7 @@ import 'package:flutter/rendering.dart' show RenderRepaintBoundary;
 import 'package:flutter/services.dart' show rootBundle, ByteData;
 
 import '../utils/th_format.dart';
+import '../services/thermal_printer_service.dart';
 
 class ReceiptPreviewPage extends StatefulWidget {
   final dynamic receipt;
@@ -138,9 +139,17 @@ class _ReceiptPreviewPageState extends State<ReceiptPreviewPage> {
   }
 
   Future<void> _sendToPrinter() async {
-    if (kDebugMode) {
+    if (_lastPng == null) return;
+    try {
+      await ThermalPrinterService.instance.printImage(_lastPng!);
+      if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('สาธิต: ส่งภาพ (${_lastPng?.lengthInBytes ?? 0} bytes) ไปที่เครื่องพิมพ์')),
+        const SnackBar(content: Text('ส่งไปยังเครื่องพิมพ์เรียบร้อย')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('พิมพ์ล้มเหลว: $e')),
       );
     }
   }

--- a/lib/features/printing/services/thermal_printer_service.dart
+++ b/lib/features/printing/services/thermal_printer_service.dart
@@ -1,0 +1,40 @@
+import 'dart:typed_data';
+
+import 'package:blue_thermal_printer/blue_thermal_printer.dart';
+
+/// Simple wrapper around [BlueThermalPrinter] to handle connection and
+/// printing images to a thermal printer via Bluetooth.
+class ThermalPrinterService {
+  ThermalPrinterService._();
+  static final ThermalPrinterService instance = ThermalPrinterService._();
+
+  final BlueThermalPrinter _bluetooth = BlueThermalPrinter.instance;
+  bool _connected = false;
+
+  /// Connects to the first bonded device if not already connected.
+  Future<void> _ensureConnected() async {
+    if (_connected) return;
+    final devices = await _bluetooth.getBondedDevices();
+    if (devices.isEmpty) {
+      throw Exception('ไม่พบเครื่องพิมพ์ที่จับคู่ไว้');
+    }
+    // Connect to the first paired device.
+    await _bluetooth.connect(devices.first);
+    _connected = true;
+  }
+
+  /// Sends raw image bytes to the printer.
+  Future<void> printImage(Uint8List bytes) async {
+    await _ensureConnected();
+    await _bluetooth.printImageBytes(bytes);
+    await _bluetooth.paperCut();
+  }
+
+  /// Disconnect from the printer if connected.
+  Future<void> disconnect() async {
+    if (_connected) {
+      await _bluetooth.disconnect();
+      _connected = false;
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   permission_handler: ^11.2.0
   provider: ^6.0.5
   cached_network_image: ^3.3.1
+  blue_thermal_printer: ^1.2.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.f


### PR DESCRIPTION
## Summary
- enable thermal printing for receipts and appointment slips via Bluetooth
- add BlueThermalPrinter service wrapper
- include blue_thermal_printer dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format lib/features/printing/services/thermal_printer_service.dart lib/features/printing/render/receipt_renderer_mydent.dart lib/features/printing/render/appointment_slip_preview_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ec0ceb784832bbbf375a5278b3fec